### PR TITLE
Fix Cromwell disk calculation in aligner checker WDL

### DIFF
--- a/aligner/functional-equivalence-checker/topmed-alignment-checker.wdl
+++ b/aligner/functional-equivalence-checker/topmed-alignment-checker.wdl
@@ -3,7 +3,14 @@ task checkerTask {
   Int expectedNumofReads
   String docker_image
 
-  Float disk_size = size(inputCRAMFile, "GB")
+  # Optional input to increase all disk sizes in case of outlier sample with strange size behavior
+  Int? increase_disk_size
+
+  # Some tasks need wiggle room, and we also need to add a small amount of disk to prevent getting a
+  # Cromwell error from asking for 0 disk when the input is less than 1GB
+  Int additional_disk = select_first([increase_disk_size, 20])
+
+  Float disk_size = size(inputCRAMFile, "GB") + additional_disk
 
   command {
     printf "The CRAM file is ${inputCRAMFile}"

--- a/aligner/u_of_michigan_aligner-checker/u_of_michigan_aligner_checker.wdl
+++ b/aligner/u_of_michigan_aligner-checker/u_of_michigan_aligner_checker.wdl
@@ -1,5 +1,5 @@
 import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.11.0/aligner/u_of_michigan_aligner/u_of_michigan_aligner.wdl" as TopMed_aligner
-import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.11.0/aligner/functional-equivalence-checker/topmed-alignment-checker.wdl" as checker
+import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.12.0/aligner/functional-equivalence-checker/topmed-alignment-checker.wdl" as checker
 
 workflow checkerWorkflow {
   Int expectedNumofReads

--- a/aligner/u_of_michigan_aligner-checker/u_of_michigan_aligner_checker.wdl
+++ b/aligner/u_of_michigan_aligner-checker/u_of_michigan_aligner_checker.wdl
@@ -1,5 +1,5 @@
-import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.11.0/aligner/u_of_michigan_aligner/u_of_michigan_aligner.wdl" as TopMed_aligner
-import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.12.0/aligner/functional-equivalence-checker/topmed-alignment-checker.wdl" as checker
+import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.13.0/aligner/u_of_michigan_aligner/u_of_michigan_aligner.wdl" as TopMed_aligner
+import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.13.0/aligner/functional-equivalence-checker/topmed-alignment-checker.wdl" as checker
 
 workflow checkerWorkflow {
   Int expectedNumofReads


### PR DESCRIPTION
Fix Cromwell disk calculation in aligner checker WDL so the disk size is greater than 0 if an input CRAM is less than 1 GB