### PR TITLE
Feature/extra disk

### DIFF
--- a/aligner/u_of_michigan_aligner-checker/u_of_michigan_aligner_checker.json
+++ b/aligner/u_of_michigan_aligner-checker/u_of_michigan_aligner_checker.json
@@ -16,5 +16,5 @@
   "checkerWorkflow.dbSNP_vcf": "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/Homo_sapiens_assembly38.dbsnp138.vcf.gz",
   "checkerWorkflow.dbSNP_vcf_index": "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/Homo_sapiens_assembly38.dbsnp138.vcf.gz.tbi",
 
-  "checkerWorkflow.docker_image": "statgen/alignment"
+  "checkerWorkflow.docker_image": "statgen/alignment:1.0.0"
 }

--- a/aligner/u_of_michigan_aligner-checker/u_of_michigan_aligner_checker.wdl
+++ b/aligner/u_of_michigan_aligner-checker/u_of_michigan_aligner_checker.wdl
@@ -1,5 +1,5 @@
-import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.15.0/aligner/u_of_michigan_aligner/u_of_michigan_aligner.wdl" as TopMed_aligner
-import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.15.0/aligner/u_of_michigan_aligner-checker/u_of_michigan_aligner_checker_calculation.wdl" as checker
+import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.17.0/aligner/u_of_michigan_aligner/u_of_michigan_aligner.wdl" as TopMed_aligner
+import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.17.0/aligner/u_of_michigan_aligner-checker/u_of_michigan_aligner_checker_calculation.wdl" as checker
 
 workflow checkerWorkflow {
   String docker_image

--- a/aligner/u_of_michigan_aligner/u_of_michigan_aligner.json
+++ b/aligner/u_of_michigan_aligner/u_of_michigan_aligner.json
@@ -14,5 +14,5 @@
   "TopMedAligner.dbSNP_vcf": "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/Homo_sapiens_assembly38.dbsnp138.vcf.gz",
   "TopMedAligner.dbSNP_vcf_index": "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/Homo_sapiens_assembly38.dbsnp138.vcf.gz.tbi",
 
-  "TopMedAligner.docker_image": "statgen/alignment"
+  "TopMedAligner.docker_image": "statgen/alignment:1.0.0"
 }

--- a/aligner/u_of_michigan_aligner/u_of_michigan_aligner.wdl
+++ b/aligner/u_of_michigan_aligner/u_of_michigan_aligner.wdl
@@ -57,19 +57,17 @@ workflow TopMedAligner {
   Float ref_extra_size = size(ref_alt, "GB") + size(ref_bwt, "GB") + size(ref_pac, "GB") + size(ref_ann, "GB") + size(ref_amb, "GB") + size(ref_sa, "GB")
   Float dbsnp_size = size(dbSNP_vcf, "GB") + size(dbSNP_vcf_index, "GB")
   Float cram_size = size(input_cram_file, "GB") + size(input_crai_file, "GB")
+  Float fastq_gz_files_size = CRAM_to_fastqgz_multiplier * cram_size
 
   call PreAlign {
      input:
       input_crai = input_crai_file,
       input_cram = input_cram_file,
-      disk_size = ref_size + (bwa_disk_multiplier * cram_size) + (sort_sam_disk_multiplier * cram_size) + cram_size + additional_disk,
+      disk_size = ref_size + (bwa_disk_multiplier * cram_size) + (sort_sam_disk_multiplier * cram_size) + cram_size + additional_disk + fastq_gz_files_size,
       docker_image = docker_image,
       ref_fasta = ref_fasta,
       ref_fasta_index = ref_fasta_index
   }
-
-
-  Float fastq_gz_files_size = CRAM_to_fastqgz_multiplier * cram_size
 
   call Align {
      input:

--- a/variant-caller/variant-caller-wdl-checker/topmed_freeze3_calling_checker.wdl
+++ b/variant-caller/variant-caller-wdl-checker/topmed_freeze3_calling_checker.wdl
@@ -1,6 +1,5 @@
-
-import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.16.0/variant-caller/variant-caller-wdl/topmed_freeze3_calling.wdl" as TopMed_variantcaller
-import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.16.0/variant-caller/variant-caller-wdl-checker/topmed-variantcaller-checker.wdl" as checker
+import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.17.0/variant-caller/variant-caller-wdl/topmed_freeze3_calling.wdl" as TopMed_variantcaller
+import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.17.0/variant-caller/variant-caller-wdl-checker/topmed-variantcaller-checker.wdl" as checker
 
 workflow checkerWorkflow {
   File inputTruthVCFFile

--- a/variant-caller/variant-caller-wdl/topmed_freeze3_calling.wdl
+++ b/variant-caller/variant-caller-wdl/topmed_freeze3_calling.wdl
@@ -1,4 +1,4 @@
-import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.14.0/variant-caller/variant-caller-wdl/calculate_contamination.wdl" as getDNAContamination
+import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.17.0/variant-caller/variant-caller-wdl/calculate_contamination.wdl" as getDNAContamination
 
 ## This is the U of Michigan variant caller workflow WDL for the workflow code located here:
 ## https://github.com/statgen/topmed_freeze3_calling


### PR DESCRIPTION
bump version to anticipated latest 1.17.0 for links to other WDL scripts in the checker workflows
fix aligner disk size calculation to provide more disk space on FireCloud for the PreAlign task
Add a version number to the Docker image