### PR TITLE
Fix expected md5sum, javascript variable, writable dir for index generation

### DIFF
--- a/aligner/sbg-alignment-cwl/steps/alignment-validation.cwl
+++ b/aligner/sbg-alignment-cwl/steps/alignment-validation.cwl
@@ -83,3 +83,8 @@ requirements:
   - class: DockerRequirement
     dockerPull: 'statgen/alignment:1.0.0'
   - class: InlineJavascriptRequirement
+  - class: InitialWorkDirRequirement
+    listing:
+      - $(inputs.cram)
+      - $(inputs.reference)
+

--- a/aligner/sbg-alignment-cwl/steps/alignment-validation.cwl
+++ b/aligner/sbg-alignment-cwl/steps/alignment-validation.cwl
@@ -52,9 +52,9 @@ arguments:
     shellQuote: false
     valueFrom: |
       ${
-          input_filename = inputs.cram.path.split('/').pop()
-          input_name_base = input_filename.split('.').slice(0,-1).join('.')
-          aux = "--output-fmt SAM -o " + input_name_base + ".sam"
+          var input_filename = inputs.cram.path.split('/').pop()
+          var input_name_base = input_filename.split('.').slice(0,-1).join('.')
+          var aux = "--output-fmt SAM -o " + input_name_base + ".sam"
           return aux
       }
   - position: 4
@@ -62,9 +62,9 @@ arguments:
     shellQuote: false
     valueFrom: |-
       ${
-          ret = "&& md5=$(md5sum "
-          input_filename = inputs.cram.path.split('/').pop()
-          input_name_base = input_filename.split('.').slice(0,-1).join('.')
+          var ret = "&& md5=$(md5sum "
+          var input_filename = inputs.cram.path.split('/').pop()
+          var input_name_base = input_filename.split('.').slice(0,-1).join('.')
           return ret + input_name_base + ".sam | awk '{ print $1 }') && if [ $md5 = " 
       }
   - position: 11

--- a/aligner/sbg-alignment-cwl/topmed-alignment-checker.sample.json
+++ b/aligner/sbg-alignment-cwl/topmed-alignment-checker.sample.json
@@ -15,5 +15,5 @@
         "class": "File",
         "path": "gs://topmed_workflow_testing/topmed_variant_caller/reference_files/hg38/hs38DH.fa"
     },
-    "expected_md5" : "e1787d34888a8ad9620b7a98bb4e8012"
+    "expected_md5" : "186d2cdf1efdc2746e6d3b26cd887c0a"
 }


### PR DESCRIPTION
Aligner and Aligner Checker:
Fix javascript variable undefined error
Correct md5sum expected
 Allow generation of indexes from writable directory when using cwltool which makes the file system read only