### PR TITLE
Enable disk size override for FireCloud and fix variant caller

### DIFF
--- a/CRAM-no-header-md5sum/CRAM_md5sum_checker_wrapper.wdl
+++ b/CRAM-no-header-md5sum/CRAM_md5sum_checker_wrapper.wdl
@@ -1,5 +1,5 @@
-import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.26.0/CRAM-no-header-md5sum/md5sum/CRAM_md5sum.wdl" as f1
-import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.26.0/CRAM-no-header-md5sum/checker/CRAM_md5sum_checker.wdl" as f2
+import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.27.0/CRAM-no-header-md5sum/md5sum/CRAM_md5sum.wdl" as f1
+import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.27.0/CRAM-no-header-md5sum/checker/CRAM_md5sum_checker.wdl" as f2
 
 workflow CRAMMd5sumChecker {
   File inputCRAMFile

--- a/aligner/functional-equivalence-checker/checker-workflow-wrapping-alignment-workflow.wdl
+++ b/aligner/functional-equivalence-checker/checker-workflow-wrapping-alignment-workflow.wdl
@@ -1,5 +1,5 @@
-import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.26.0/aligner/functional-equivalence-wdl/FunctionalEquivalence.wdl" as TopMed_aligner
-import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.26.0/aligner/functional-equivalence-checker/topmed-alignment-checker.wdl" as checker
+import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.27.0/aligner/functional-equivalence-wdl/FunctionalEquivalence.wdl" as TopMed_aligner
+import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.27.0/aligner/functional-equivalence-checker/topmed-alignment-checker.wdl" as checker
 
 workflow checkerWorkflow {
   Int expectedNumofReads

--- a/aligner/u_of_michigan_aligner-checker/u_of_michigan_aligner_checker.wdl
+++ b/aligner/u_of_michigan_aligner-checker/u_of_michigan_aligner_checker.wdl
@@ -1,5 +1,5 @@
-import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.26.0/aligner/u_of_michigan_aligner/u_of_michigan_aligner.wdl" as TopMed_aligner
-import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.26.0/aligner/u_of_michigan_aligner-checker/u_of_michigan_aligner_checker_calculation.wdl" as checker
+import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.27.0/aligner/u_of_michigan_aligner/u_of_michigan_aligner.wdl" as TopMed_aligner
+import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.27.0/aligner/u_of_michigan_aligner-checker/u_of_michigan_aligner_checker_calculation.wdl" as checker
 
 
 workflow checkerWorkflow {

--- a/aligner/u_of_michigan_aligner/u_of_michigan_aligner.wdl
+++ b/aligner/u_of_michigan_aligner/u_of_michigan_aligner.wdl
@@ -124,6 +124,8 @@ workflow TopMedAligner {
 #      Float dbsnp_size = size(dbSNP_vcf, "GB") + size(dbSNP_vcf_index, "GB")
 #      Float cram_size = size(input_cram_file, "GB") + size(input_crai_file, "GB")
 #      Float fastq_gz_files_size = CRAM_to_fastqgz_multiplier * cram_size
+  Float PreAlign_ref_size = if (defined(dynamically_calculate_disk_requirement)) then size(PreAlign_reference_genome_default, "GB") + size(PreAlign_reference_genome_index_default, "GB") + 
+      additional_disk else ReferenceGenome_disk_size_override_default + additional_disk
 
   Float ref_size = if (defined(dynamically_calculate_disk_requirement)) then size(ref_fasta, "GB") + size(ref_fasta_index, "GB") + 
       additional_disk else ReferenceGenome_disk_size_override_default + additional_disk
@@ -142,7 +144,7 @@ workflow TopMedAligner {
 
 
 
-  Float PreAlign_disk_size = ref_size + (bwa_disk_multiplier * cram_and_crai_size) + 
+  Float PreAlign_disk_size = PreAlign_ref_size + (bwa_disk_multiplier * cram_and_crai_size) + 
      (sort_sam_disk_multiplier * cram_and_crai_size) + cram_and_crai_size + additional_disk + fastq_gz_files_size
 
   Float Align_disk_size = ref_size + ref_extra_size + (bwa_disk_multiplier * fastq_gz_files_size) + additional_disk

--- a/aligner/u_of_michigan_aligner/u_of_michigan_aligner.wdl
+++ b/aligner/u_of_michigan_aligner/u_of_michigan_aligner.wdl
@@ -118,12 +118,6 @@ workflow TopMedAligner {
   Float sort_sam_disk_multiplier = 3.25
 
 
-#      # Get the size of the standard reference files as well as the additional reference files needed for BWA
-#      Float ref_size = size(ref_fasta, "GB") + size(ref_fasta_index, "GB")
-#      Float ref_extra_size = size(ref_alt, "GB") + size(ref_bwt, "GB") + size(ref_pac, "GB") + size(ref_ann, "GB") + size(ref_amb, "GB") + size(ref_sa, "GB")
-#      Float dbsnp_size = size(dbSNP_vcf, "GB") + size(dbSNP_vcf_index, "GB")
-#      Float cram_size = size(input_cram_file, "GB") + size(input_crai_file, "GB")
-#      Float fastq_gz_files_size = CRAM_to_fastqgz_multiplier * cram_size
   Float PreAlign_ref_size = if (defined(dynamically_calculate_disk_requirement)) then size(PreAlign_reference_genome_default, "GB") + size(PreAlign_reference_genome_index_default, "GB") + 
       additional_disk else ReferenceGenome_disk_size_override_default + additional_disk
 
@@ -162,7 +156,6 @@ workflow TopMedAligner {
       ref_fasta = PreAlign_reference_genome_default,
       ref_fasta_index = PreAlign_reference_genome_index_default,
 
-      #disk_size = ref_size + (bwa_disk_multiplier * cram_size) + (sort_sam_disk_multiplier * cram_size) + cram_size + additional_disk + fastq_gz_files_size,
       disk_size = PreAlign_disk_size,
       docker_image = docker_image,
       CPUs = PreAlign_CPUs_default,
@@ -176,7 +169,6 @@ workflow TopMedAligner {
       input_list_file = PreAlign.output_list_file,
       input_fastq_gz_files = PreAlign.output_fastq_gz_files,
 
-      #disk_size = ref_size + ref_extra_size + (bwa_disk_multiplier * fastq_gz_files_size) + additional_disk,
       disk_size = Align_disk_size,
       docker_image = docker_image,
       CPUs = Align_CPUs_default,
@@ -196,7 +188,6 @@ workflow TopMedAligner {
 
   }
 
-  #Float CRAMS_files_size = fastq_gz_to_CRAM_multiplier * cram_size
 
   call PostAlign {
      input:
@@ -205,7 +196,6 @@ workflow TopMedAligner {
       # The merged cram can be bigger than the summed sizes of the individual aligned crams,
       # so account for the output size by multiplying the input size by bwa disk multiplier.
       disk_size = PostAlign_disk_size,
-      #disk_size = ref_size + dbsnp_size + CRAMS_files_size + (sort_sam_disk_multiplier * CRAMS_files_size) + (bwa_disk_multiplier * CRAMS_files_size) + additional_disk,
       docker_image = docker_image,
       max_retries = PostAlign_max_retries_default,
       preemptible_tries = PostAlign_preemptible_tries_default,

--- a/aligner/u_of_michigan_aligner/u_of_michigan_aligner.wdl
+++ b/aligner/u_of_michigan_aligner/u_of_michigan_aligner.wdl
@@ -30,6 +30,15 @@ workflow TopMedAligner {
   File dbSNP_vcf
   File dbSNP_vcf_index
 
+  # The CRAM to be realigned may have been aligned with a different reference
+  # genome than what will be used in the alignment step. The pre align step
+  # must use the reference genome that the CRAM was originally aligned with
+  # to convert the CRAM to a SAM
+  File? PreAlign_reference_genome
+  File PreAlign_reference_genome_default = select_first([PreAlign_reference_genome,ref_fasta])
+  File? PreAlign_reference_genome_index
+  File PreAlign_reference_genome_index_default = select_first([PreAlign_reference_genome_index,ref_fasta_index])
+
   Int? PreAlign_preemptible_tries
   Int PreAlign_preemptible_tries_default = select_first([PreAlign_preemptible_tries, 3])
   Int? PreAlign_max_retries
@@ -148,8 +157,8 @@ workflow TopMedAligner {
      input:
       input_crai = input_crai_file,
       input_cram = input_cram_file,
-      ref_fasta = ref_fasta,
-      ref_fasta_index = ref_fasta_index,
+      ref_fasta = PreAlign_reference_genome_default,
+      ref_fasta_index = PreAlign_reference_genome_index_default,
 
       #disk_size = ref_size + (bwa_disk_multiplier * cram_size) + (sort_sam_disk_multiplier * cram_size) + cram_size + additional_disk + fastq_gz_files_size,
       disk_size = PreAlign_disk_size,

--- a/aligner/u_of_michigan_aligner/u_of_michigan_aligner.wdl
+++ b/aligner/u_of_michigan_aligner/u_of_michigan_aligner.wdl
@@ -30,8 +30,18 @@ workflow TopMedAligner {
   File dbSNP_vcf
   File dbSNP_vcf_index
 
-  Int? preemptible_tries
-  Int preemptible_tries_default = select_first([preemptible_tries, 3])
+  Int? PreAlign_preemptible_tries
+  Int PreAlign_preemptible_tries_default = select_first([PreAlign_preemptible_tries, 3])
+
+  Int? Align_preemptible_tries
+  Int Align_preemptible_tries_default = select_first([Align_preemptible_tries, 3])
+
+  # Use one preemptible try for post alignment becuase it often takes more than 24 
+  # hours and GCP preemptible nodes are terminated after 24 hours by GCP
+  # https://cloud.google.com/compute/docs/instances/preemptible
+  # "Compute Engine always terminates preemptible instances after they run for 24 hours."
+  Int? PostAlign_preemptible_tries
+  Int PostAlign_preemptible_tries_default = select_first([PostAlign_preemptible_tries, 1])
 
   Int? PreAlign_CPUs
   Int PreAlign_CPUs_default = select_first([PreAlign_CPUs, 1])
@@ -50,6 +60,21 @@ workflow TopMedAligner {
 
   Float? PostAlign_mem
   Float PostAlign_mem_default = select_first([PostAlign_mem, 6.5])
+
+  Boolean? dynamically_calculate_file_size
+  Boolean dynamically_calculate_disk_requirement = select_first([dynamically_calculate_file_size, true])
+
+  Float? CRAMandCRAI_disk_size_override
+  Float CRAMandCRAI_disk_size_override_default = select_first([CRAMandCRAI_disk_size_override, 80])
+
+  Float? ReferenceGenome_disk_size_override
+  Float ReferenceGenome_disk_size_override_default = select_first([ReferenceGenome_disk_size_override, 6.0])
+
+  Float? BWT_disk_size_override
+  Float BWT_disk_size_override_default = select_first([BWT_disk_size_override, 2.0])
+
+  Float? dbSNP_disk_size_override
+  Float dbSNP_disk_size_override_default = select_first([dbSNP_disk_size_override, 2.0])
 
   # Get the file name only with no path and no .cram suffix
   String input_cram_name = basename("${input_cram_file}", ".cram")
@@ -76,24 +101,54 @@ workflow TopMedAligner {
   # larger multiplier
   Float sort_sam_disk_multiplier = 3.25
 
-  # Get the size of the standard reference files as well as the additional reference files needed for BWA
-  Float ref_size = size(ref_fasta, "GB") + size(ref_fasta_index, "GB")
-  Float ref_extra_size = size(ref_alt, "GB") + size(ref_bwt, "GB") + size(ref_pac, "GB") + size(ref_ann, "GB") + size(ref_amb, "GB") + size(ref_sa, "GB")
-  Float dbsnp_size = size(dbSNP_vcf, "GB") + size(dbSNP_vcf_index, "GB")
-  Float cram_size = size(input_cram_file, "GB") + size(input_crai_file, "GB")
-  Float fastq_gz_files_size = CRAM_to_fastqgz_multiplier * cram_size
+
+#      # Get the size of the standard reference files as well as the additional reference files needed for BWA
+#      Float ref_size = size(ref_fasta, "GB") + size(ref_fasta_index, "GB")
+#      Float ref_extra_size = size(ref_alt, "GB") + size(ref_bwt, "GB") + size(ref_pac, "GB") + size(ref_ann, "GB") + size(ref_amb, "GB") + size(ref_sa, "GB")
+#      Float dbsnp_size = size(dbSNP_vcf, "GB") + size(dbSNP_vcf_index, "GB")
+#      Float cram_size = size(input_cram_file, "GB") + size(input_crai_file, "GB")
+#      Float fastq_gz_files_size = CRAM_to_fastqgz_multiplier * cram_size
+
+  Float ref_size = if (defined(dynamically_calculate_disk_requirement)) then size(ref_fasta, "GB") + size(ref_fasta_index, "GB") + 
+      additional_disk else ReferenceGenome_disk_size_override_default + additional_disk
+
+  Float ref_extra_size = if (defined(dynamically_calculate_disk_requirement)) then size(ref_alt, "GB") + size(ref_bwt, "GB") + size(ref_pac, "GB") + 
+      size(ref_ann, "GB") + size(ref_amb, "GB") + size(ref_sa, "GB") + 
+      additional_disk else BWT_disk_size_override_default + additional_disk
+
+  Float dbsnp_size =if (defined(dynamically_calculate_disk_requirement)) then size(dbSNP_vcf, "GB") + size(dbSNP_vcf_index, "GB") + 
+     additional_disk else dbSNP_disk_size_override_default + additional_disk
+
+  Float cram_and_crai_size = if (defined(dynamically_calculate_disk_requirement)) then size(input_cram_file, "GB") + size(input_crai_file, "GB") + 
+     additional_disk else CRAMandCRAI_disk_size_override_default + additional_disk
+
+  Float fastq_gz_files_size = CRAM_to_fastqgz_multiplier * cram_and_crai_size
+
+
+
+  Float PreAlign_disk_size = ref_size + (bwa_disk_multiplier * cram_and_crai_size) + 
+     (sort_sam_disk_multiplier * cram_and_crai_size) + cram_and_crai_size + additional_disk + fastq_gz_files_size
+
+  Float Align_disk_size = ref_size + ref_extra_size + (bwa_disk_multiplier * fastq_gz_files_size) + additional_disk
+
+  # The merged cram can be bigger than the summed sizes of the individual aligned crams,
+  # so account for the output size by multiplying the input size by bwa disk multiplier.
+  Float PostAlign_disk_size = ref_size + dbsnp_size + cram_and_crai_size + 
+     (sort_sam_disk_multiplier * cram_and_crai_size) + (bwa_disk_multiplier * cram_and_crai_size) + additional_disk
+
 
   call PreAlign {
      input:
       input_crai = input_crai_file,
       input_cram = input_cram_file,
-      disk_size = ref_size + (bwa_disk_multiplier * cram_size) + (sort_sam_disk_multiplier * cram_size) + cram_size + additional_disk + fastq_gz_files_size,
+      #disk_size = ref_size + (bwa_disk_multiplier * cram_size) + (sort_sam_disk_multiplier * cram_size) + cram_size + additional_disk + fastq_gz_files_size,
+      disk_size = PreAlign_disk_size,
       docker_image = docker_image,
       ref_fasta = ref_fasta,
       ref_fasta_index = ref_fasta_index,
       PreAlign_CPUs_default = PreAlign_CPUs_default,
       PreAlign_mem_default = PreAlign_mem_default,
-      preemptible_tries_default = preemptible_tries_default
+      preemptible_tries_default = PreAlign_preemptible_tries_default
   }
 
   call Align {
@@ -101,7 +156,9 @@ workflow TopMedAligner {
       input_list_file = PreAlign.output_list_file,
       input_fastq_gz_files = PreAlign.output_fastq_gz_files,
 
-      disk_size = ref_size + ref_extra_size + (bwa_disk_multiplier * fastq_gz_files_size) + additional_disk,
+      #disk_size = ref_size + ref_extra_size + (bwa_disk_multiplier * fastq_gz_files_size) + additional_disk,
+      disk_size = Align_disk_size,
+
       docker_image = docker_image,
 
       ref_alt = ref_alt,
@@ -114,11 +171,11 @@ workflow TopMedAligner {
       ref_fasta_index = ref_fasta_index,
       Align_CPUs_default = Align_CPUs_default,
       Align_mem_default = Align_mem_default,
-      preemptible_tries_default = preemptible_tries_default
+      preemptible_tries_default = Align_preemptible_tries_default
 
   }
 
-  Float CRAMS_files_size = fastq_gz_to_CRAM_multiplier * cram_size
+  #Float CRAMS_files_size = fastq_gz_to_CRAM_multiplier * cram_size
 
   call PostAlign {
      input:
@@ -126,7 +183,8 @@ workflow TopMedAligner {
 
       # The merged cram can be bigger than the summed sizes of the individual aligned crams,
       # so account for the output size by multiplying the input size by bwa disk multiplier.
-      disk_size = ref_size + dbsnp_size + CRAMS_files_size + (sort_sam_disk_multiplier * CRAMS_files_size) + (bwa_disk_multiplier * CRAMS_files_size) + additional_disk,
+      disk_size = PostAlign_disk_size,
+      #disk_size = ref_size + dbsnp_size + CRAMS_files_size + (sort_sam_disk_multiplier * CRAMS_files_size) + (bwa_disk_multiplier * CRAMS_files_size) + additional_disk,
       docker_image = docker_image,
 
       ref_fasta = ref_fasta,
@@ -138,7 +196,7 @@ workflow TopMedAligner {
       PostAlign_mem_default = PostAlign_mem_default,
 
       input_cram_name = input_cram_name,
-      preemptible_tries_default = preemptible_tries_default
+      preemptible_tries_default = PostAlign_preemptible_tries_default
 
   }
 
@@ -350,8 +408,6 @@ task PostAlign {
         rc=$?
         [[ $rc != 0 ]] && break
         rm -f ${dollar}{input_file} ${dollar}{tmp_prefix}*
-        # Remove the tmp file; no need to remove the input file from the previous task
-#        rm -f ${dollar}{tmp_prefix}*
       done
 
       if [[ $rc == 0 ]]

--- a/variant-caller/variant-caller-wdl-checker/topmed_freeze3_calling_checker.wdl
+++ b/variant-caller/variant-caller-wdl-checker/topmed_freeze3_calling_checker.wdl
@@ -1,5 +1,5 @@
-import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.26.0/variant-caller/variant-caller-wdl/topmed_freeze3_calling.wdl" as TopMed_variantcaller
-import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.26.0/variant-caller/variant-caller-wdl-checker/topmed-variantcaller-checker.wdl" as checker
+import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.27.0/variant-caller/variant-caller-wdl/topmed_freeze3_calling.wdl" as TopMed_variantcaller
+import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.27.0/variant-caller/variant-caller-wdl-checker/topmed-variantcaller-checker.wdl" as checker
 
 workflow checkerWorkflow {
   File inputTruthVCFFile

--- a/variant-caller/variant-caller-wdl/calculate_contamination.wdl
+++ b/variant-caller/variant-caller-wdl/calculate_contamination.wdl
@@ -54,7 +54,7 @@ workflow calulateDNAContamination {
   String? reference_genome_version
   String reference_genome = select_first([reference_genome_version, 'hg38'])
 
-  String? docker_image = "quay.io/ucsc_cgl/verifybamid:1.26.0"
+  String? docker_image = "quay.io/ucsc_cgl/verifybamid:1.27.0"
 
   call VerifyBamID {
      input:

--- a/variant-caller/variant-caller-wdl/topmed_freeze3_calling.wdl
+++ b/variant-caller/variant-caller-wdl/topmed_freeze3_calling.wdl
@@ -755,8 +755,8 @@ workflow TopMedVariantCaller {
       CODE
 
 
-      set -o pipefail
-      set -e
+      #set -o pipefail
+      #set -e
 
       #echo each line of the script to stdout so we can see what is happening
       set -o xtrace

--- a/variant-caller/variant-caller-wdl/topmed_freeze3_calling.wdl
+++ b/variant-caller/variant-caller-wdl/topmed_freeze3_calling.wdl
@@ -91,9 +91,9 @@ workflow TopMedVariantCaller {
   Array[String] input_cram_files_names = input_cram_files
 
   String docker_image
-  String? docker_contamination_image   = "quay.io/ucsc_cgl/verifybamid:1.26.0"
+  String? docker_contamination_image   = "quay.io/ucsc_cgl/verifybamid:1.27.0"
 
-  String? docker_create_index_image  = "quay.io/ucsc_cgl/verifybamid:1.26.0"
+  String? docker_create_index_image  = "quay.io/ucsc_cgl/verifybamid:1.27.0"
 
   File ref_1000G_omni2_5_b38_sites_PASS_vcf_gz
   File ref_1000G_omni2_5_b38_sites_PASS_vcf_gz_tbi

--- a/variant-caller/variant-caller-wdl/topmed_freeze3_calling.wdl
+++ b/variant-caller/variant-caller-wdl/topmed_freeze3_calling.wdl
@@ -1,4 +1,7 @@
-import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.26.0/variant-caller/variant-caller-wdl/calculate_contamination.wdl" as getDNAContamination
+#import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.26.0/variant-caller/variant-caller-wdl/calculate_contamination.wdl" as getDNAContamination
+import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/feature/TLP-551-enable-disk-size-override/variant-caller/variant-caller-wdl/calculate_contamination.wdl" as getDNAContamination
+
+#import "/Users/waltershands/Documents/UCSC/gitroot/topmed-workflows/variant-caller/variant-caller-wdl/calculate_contamination.wdl" as getDNAContamination
 
 ## This is the U of Michigan variant caller workflow WDL for the workflow code located here:
 ## https://github.com/statgen/topmed_freeze3_calling
@@ -17,20 +20,70 @@ workflow TopMedVariantCaller {
   Boolean? calculate_DNA_contamination
   Boolean calculate_contamination = select_first([calculate_DNA_contamination, true])
 
-  Int? preemptible_tries
-  Int preemptible_tries_default = select_first([preemptible_tries, 3])
+  Boolean? dynamically_calculate_file_size
+  Boolean dynamically_calculate_disk_requirement = select_first([dynamically_calculate_file_size, true])
 
-  Int? variant_caller_mem
-  Int variant_caller_mem_default = select_first([variant_caller_mem, 10])
+  Float? All_CRAMs_disk_size_override
+  Float All_CRAMs_disk_size_override_default = select_first([All_CRAMs_disk_size_override, 1000.0])
 
+  Float? All_CRAIs_disk_size_override
+  Float All_CRAIs_disk_size_override_default = select_first([All_CRAIs_disk_size_override, 100.0])
+
+  Float? CRAM_file_max_disk_size_override
+  Float CRAM_file_max_disk_size_override_default = select_first([CRAM_file_max_disk_size_override, 200.0])
+
+  Float? ReferenceGenome_disk_size_override
+  Float ReferenceGenome_disk_size_override_default = select_first([ReferenceGenome_disk_size_override, 30.0])
+
+  Int? SumFileSizes_preemptible_tries
+  Int  SumFileSizes_preemptible_tries_default = select_first([SumFileSizes_preemptible_tries, 3])
+  Int? SumFileSizes_maxretries_tries
+  Int SumFileSizes_maxretries_tries_default = select_first([SumFileSizes_maxretries_tries, 3])
+  Int? SumFileSizes_memory
+  Int SumFileSizes_memory_default = select_first([SumFileSizes_memory, 7])
+  Int? SumFileSizes_CPUs
+  Int SumFileSizes_CPUs_default = select_first([SumFileSizes_CPUs, 1])
+  Int? SumFileSizes_disk_size
+  Int SumFileSizes_disk_size_default = select_first([SumFileSizes_disk_size, 1])
+
+  Int? CreateCRAMIndex_preemptible_tries
+  Int CreateCRAMIndex_preemptible_tries_default = select_first([CreateCRAMIndex_preemptible_tries, 3])
+  Int? CreateCRAMIndex_maxretries_tries
+  Int CreateCRAMIndex_maxretries_tries_default = select_first([CreateCRAMIndex_maxretries_tries, 3])
+  Int? CreateCRAMIndex_memory
+  Int CreateCRAMIndex_memory_default = select_first([CreateCRAMIndex_memory, 7])
+  Int? CreateCRAMIndex_CPUs
+  Int CreateCRAMIndex_CPUs_default = select_first([CreateCRAMIndex_CPUs, 1])
+
+  Int? CalcContamination_preemptible_tries
+  Int CalcContamination_preemptible_tries_default = select_first([CalcContamination_preemptible_tries, 3])
+  Int? CalcContamination_maxretries_tries
+  Int CalcContamination_maxretries_tries_default = select_first([CalcContamination_maxretries_tries, 3])
+  Int? CalcContamination_mem
+  Int CalcContamination_mem_default = select_first([CalcContamination_mem, 100 ])
   Int? CalcContamination_CPUs
   Int CalcContamination_CPUs_default = select_first([CalcContamination_CPUs, 1])
 
-  Int? CalcContamination_mem
-  Int CalcContamination_mem_default = select_first([CalcContamination_mem, 10])
 
+  # The variant caller typically takes more than 24 hours to run. GCP terminates
+  #  preemptible tasks after 24 hours. So by using 0 for preemptible tries the 
+  #  task is non preemtible
+  #  if preemptible is set to 0 -- then its set to false
+  #  if preemptible is set to a positive integer -- its automatically true
+  Int? VariantCaller_preemptible_tries
+  Int VariantCaller_preemptible_tries_default = select_first([VariantCaller_preemptible_tries, 0])
+  #if preemptible is 0 and maxRetries is 3 -- then that task can be retried upto 3 times
+  #if preemptible is 3 and maxRetries is 3 for a task -- that can be retried upto 6 times
+  #https://cromwell.readthedocs.io/en/stable/RuntimeAttributes/#maxretries
+  Int? VariantCaller_maxretries_tries
+  Int VariantCaller_maxretries_tries_default = select_first([VariantCaller_maxretries_tries, 3])
+  Int? VariantCaller_memory
+  Int VariantCaller_memory_default = select_first([VariantCaller_memory, 200])
   Int? VariantCaller_CPUs
   Int VariantCaller_CPUs_default = select_first([VariantCaller_CPUs, 32])
+
+
+
 
   Array[File]? input_crai_files
   Array[File] input_cram_files
@@ -103,12 +156,13 @@ workflow TopMedVariantCaller {
 
   # Optional input to increase all disk sizes in case of outlier sample with strange size behavior
   Int? increase_disk_size
-
   # Some tasks need wiggle room, and we also need to add a small amount of disk to prevent getting a
   # Cromwell error from asking for 0 disk when the input is less than 1GB
   Int additional_disk = select_first([increase_disk_size, 20])
 
-  Float reference_size = ( 
+
+  Float reference_size = if (dynamically_calculate_disk_requirement) then
+  ( 
   size(ref_1000G_omni2_5_b38_sites_PASS_vcf_gz, "GB") +
   size(ref_1000G_omni2_5_b38_sites_PASS_vcf_gz_tbi, "GB") +
   size(chr10_vcf, "GB") +
@@ -169,29 +223,45 @@ workflow TopMedVariantCaller {
   size(ref_hs38DH_fa_sa, "GB") +
   size(ref_hs38DH_winsize100_gc, "GB")
   )
+  else ReferenceGenome_disk_size_override_default
 
-  # Use scatter to get the size of each CRAM file:
-  # Add 1 GB to size in case size is less than 1 GB
-  # Use an array of String instead of File so Cromwell doesn't try to download them
-  scatter(cram_file in input_cram_files_names ) { Float cram_file_size = round(size(cram_file, "GB")) + 1 }
-  # Gather the sizes of the CRAM files:
-  Array[Float] cram_file_sizes = cram_file_size
-  # Use a task to sum the array:
-  call sum_file_sizes as sum_cram_file_sizes { 
-    input: 
-      file_sizes = cram_file_sizes,
-      preemptible_tries = preemptible_tries_default
+
+  if (dynamically_calculate_disk_requirement) {
+      # Use scatter to get the size of each CRAM file:
+      # Add 1 GB to size in case size is less than 1 GB
+      # Use an array of String instead of File so Cromwell doesn't try to download them
+      scatter(cram_file in input_cram_files_names ) { Float cram_file_size = round(size(cram_file, "GB")) + 1 }
+      # Gather the sizes of the CRAM files:
+      Array[Float] cram_file_sizes = cram_file_size
+      # Use a task to sum the array:
+      call sum_file_sizes as sum_cram_file_sizes { 
+        input: 
+          file_sizes = cram_file_sizes,
+          preemptible_tries = SumFileSizes_preemptible_tries_default,
+          max_retries = SumFileSizes_maxretries_tries_default,
+          CPUs = SumFileSizes_CPUs_default,
+          disk_size = SumFileSizes_disk_size_default,
+          memory = SumFileSizes_memory_default
+      }
   }
   
+  #Float cram_files_size = if (dynamically_calculate_disk_requirement) then sum_cram_file_sizes.total_size else All_CRAMs_disk_size_override_default
+  Float cram_files_size = select_first([sum_cram_file_sizes.total_size, All_CRAMs_disk_size_override_default])
+
   # If no CRAM index files were input then
   # create the index files 
   if (!defined(input_crai_files)) {
       scatter(cram_file in input_cram_files) {
+          Float cram_size = if (dynamically_calculate_disk_requirement) then  size(cram_file, "GB") else  CRAM_file_max_disk_size_override_default
           call createCRAMIndex as scatter_createCRAMIndex {
             input:
               input_cram = cram_file,
-              disk_size = size(cram_file, "GB") + additional_disk, 
-              docker_image = docker_create_index_image
+              disk_size = cram_size + additional_disk,
+              docker_image = docker_create_index_image,
+              CPUs = CreateCRAMIndex_CPUs_default,
+              preemptible_tries = CreateCRAMIndex_preemptible_tries_default,
+              memory = CreateCRAMIndex_memory_default,
+              max_retries = CreateCRAMIndex_maxretries_tries_default
            }
       }
       Array[File] generated_crai_files = scatter_createCRAMIndex.output_crai_file
@@ -208,19 +278,33 @@ workflow TopMedVariantCaller {
   # sizes of the files so Cromwell doesn't try to download them
   Array[String] crai_files_names_array = crai_files_array
 
-  # Use scatter to get the size of each CRAI file:
-  # Add 1 GB to size in case size is less than 1 GB
-  scatter(crai_file in crai_files_names_array ) { Int crai_file_size = round(size(crai_file, "GB")) + 1 }
-  # Gather the sizes of the CRAI files:
-  Array[Float] crai_file_sizes_array = crai_file_size
-  # Use a task to sum the array:
-  call sum_file_sizes as sum_crai_file_sizes { 
-    input: 
-      file_sizes = crai_file_sizes_array,
-      preemptible_tries = preemptible_tries_default
+
+
+
+  if (dynamically_calculate_disk_requirement) {
+      # Use scatter to get the size of each CRAI file:
+      # Add 1 GB to size in case size is less than 1 GB
+      scatter(crai_file in crai_files_names_array ) { Float crai_file_size = round(size(crai_file, "GB")) + 1 }
+      # Gather the sizes of the CRAI files:
+      Array[Float] crai_file_sizes_array = crai_file_size
+      # Use a task to sum the array:
+      call sum_file_sizes as sum_crai_file_sizes { 
+        input: 
+          file_sizes = crai_file_sizes_array,
+          preemptible_tries = SumFileSizes_preemptible_tries_default,
+          CPUs = SumFileSizes_CPUs_default,
+          max_retries = SumFileSizes_maxretries_tries_default,
+          disk_size = SumFileSizes_disk_size_default,
+          memory = SumFileSizes_memory_default
+      }
   }
 
-  
+#  Float crai_files_size = if (dynamically_calculate_disk_requirement) then sum_crai_file_sizes.total_size else  All_CRAIs_disk_size_override_default
+#  !!!!Why do I need to do this:
+  Float crai_files_size = select_first([sum_crai_file_sizes.total_size, All_CRAIs_disk_size_override_default])
+
+
+
   if (calculate_contamination) {
       if (defined(input_crai_files)) {
           # Create an empty array to use to get around zip's requirement that
@@ -238,9 +322,11 @@ workflow TopMedVariantCaller {
                     ref_fasta = ref_hs38DH_fa,
                     ref_fasta_index = ref_hs38DH_fa_fai,
 
-                    CalcContamination_mem = CalcContamination_mem_default,
+                    dynamically_calculate_file_size = dynamically_calculate_disk_requirement,
+                    CalcContamination_memory = CalcContamination_mem_default,
                     CalcContamination_CPUs = CalcContamination_CPUs_default,
-                    preemptible_tries = preemptible_tries_default,
+                    CalcContamination_preemptible_tries = CalcContamination_preemptible_tries_default,
+                    CalcContamination_max_retries = CalcContamination_maxretries_tries,
                     docker_image = docker_contamination_image
               }
           }
@@ -260,9 +346,11 @@ workflow TopMedVariantCaller {
                     ref_fasta = ref_hs38DH_fa,
                     ref_fasta_index = ref_hs38DH_fa_fai,
 
-                    CalcContamination_mem = CalcContamination_mem_default,
-                    CalcContamination_CPUs = CalcContamination_CPUs_default, 
-                    preemptible_tries = preemptible_tries_default,
+                    dynamically_calculate_file_size = dynamically_calculate_disk_requirement,
+                    CalcContamination_memory = CalcContamination_mem_default,
+                    CalcContamination_CPUs = CalcContamination_CPUs_default,
+                    CalcContamination_preemptible_tries = CalcContamination_preemptible_tries_default,
+                    CalcContamination_max_retries = CalcContamination_maxretries_tries_default,
                     docker_image = docker_contamination_image
               }
           }
@@ -280,10 +368,13 @@ workflow TopMedVariantCaller {
 
       input_crais = crai_files,
       input_crams = input_cram_files,
-      disk_size = sum_cram_file_sizes.total_size + sum_crai_file_sizes.total_size + reference_size + additional_disk,
-      VariantCaller_CPUs_default = VariantCaller_CPUs_default,
-      preemptible_tries = preemptible_tries_default,
-      variant_caller_mem = variant_caller_mem_default,
+
+      disk_size = cram_files_size + crai_files_size + reference_size + additional_disk,
+
+      CPUs = VariantCaller_CPUs_default,
+      preemptible_tries = VariantCaller_preemptible_tries_default,
+      max_retries = VariantCaller_maxretries_tries_default,
+      memory = VariantCaller_memory_default,
 
       docker_image = docker_image,
 
@@ -357,7 +448,12 @@ workflow TopMedVariantCaller {
  
   task createCRAMIndex {
      File input_cram
+
+     Float memory
      Float disk_size
+     Int CPUs
+     Int preemptible_tries
+     Int max_retries
      String docker_image
 
      String CRAM_basename = basename(input_cram)
@@ -391,8 +487,10 @@ workflow TopMedVariantCaller {
           File output_crai_file = "${output_crai_file_name}"
        }
       runtime {
-         memory: "10 GB"
-         cpu: 1
+         memory: sub(memory, "\\..*", "") + " GB"
+         cpu: sub(CPUs, "\\..*", "")
+         maxRetries: max_retries
+         preemptible: preemptible_tries
          disks: "local-disk " + sub(disk_size, "\\..*", "") + " HDD"
          zones: "us-central1-a us-central1-b us-east1-d us-central1-c us-central1-f us-east1-c"
          docker: docker_image
@@ -403,8 +501,14 @@ workflow TopMedVariantCaller {
   # Calculates sum of a list of floats
   task sum_file_sizes {
     Array[Float] file_sizes
+
+    Float memory
+    Float disk_size
+    Int CPUs
     Int preemptible_tries
- 
+    #String docker_image
+    Int max_retries
+
     command <<<
     python -c "print ${sep="+" file_sizes}"
     >>>
@@ -414,7 +518,11 @@ workflow TopMedVariantCaller {
     runtime {
       docker: "python:2.7"
       preemptible: preemptible_tries
-      cpu: 1
+      maxRetries: max_retries
+      memory: sub(memory, "\\..*", "") + " GB"
+      cpu: sub(CPUs, "\\..*", "")
+      disks: "local-disk " + sub(disk_size, "\\..*", "") + " HDD"
+
     }
   }
 
@@ -438,12 +546,12 @@ workflow TopMedVariantCaller {
      Array[File]? input_crais
      Array[File] input_crams
 
-     Float variant_caller_mem
+     Float memory
      Float disk_size
-     Int VariantCaller_CPUs_default
+     Int CPUs
      Int preemptible_tries
-
      String docker_image
+     Int max_retries
 
      File ref_1000G_omni2_5_b38_sites_PASS_vcf_gz
      File ref_1000G_omni2_5_b38_sites_PASS_vcf_gz_tbi
@@ -796,8 +904,9 @@ workflow TopMedVariantCaller {
     }
    runtime {
       preemptible: preemptible_tries
-      memory: sub(variant_caller_mem, "\\..*", "") + " GB"
-      cpu: sub(VariantCaller_CPUs_default, "\\..*", "")
+      maxRetries: max_retries
+      memory: sub(memory, "\\..*", "") + " GB"
+      cpu: sub(CPUs, "\\..*", "")
       disks: "local-disk " + sub(disk_size, "\\..*", "") + " HDD"
       zones: "us-central1-a us-central1-b us-east1-d us-central1-c us-central1-f us-east1-c"
       docker: docker_image

--- a/variant-caller/variant-caller-wdl/topmed_freeze3_calling.wdl
+++ b/variant-caller/variant-caller-wdl/topmed_freeze3_calling.wdl
@@ -478,7 +478,6 @@ workflow TopMedVariantCaller {
       echo "Running create CRAM index"
 
       printf "Creating index ${input_cram}.crai for ${input_cram}"
-#      samtools index ${input_cram} ${input_cram}.crai
       samtools index ${input_cram} ${output_crai_file_name}
 
       >>>

--- a/variant-caller/variant-caller-wdl/topmed_freeze3_calling.wdl
+++ b/variant-caller/variant-caller-wdl/topmed_freeze3_calling.wdl
@@ -1,7 +1,4 @@
-#import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.26.0/variant-caller/variant-caller-wdl/calculate_contamination.wdl" as getDNAContamination
-import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/feature/TLP-551-enable-disk-size-override/variant-caller/variant-caller-wdl/calculate_contamination.wdl" as getDNAContamination
-
-#import "/Users/waltershands/Documents/UCSC/gitroot/topmed-workflows/variant-caller/variant-caller-wdl/calculate_contamination.wdl" as getDNAContamination
+import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.27.0/variant-caller/variant-caller-wdl/calculate_contamination.wdl" as getDNAContamination
 
 ## This is the U of Michigan variant caller workflow WDL for the workflow code located here:
 ## https://github.com/statgen/topmed_freeze3_calling
@@ -884,7 +881,7 @@ workflow TopMedVariantCaller {
       formatted_chromosomes_string=$(j=0; for i in ${chromosomes_to_process}; do printf "chr""$i"; let "j=j+1"; if [ "$j" -lt "$total" ]; then printf " "; fi done)
 
       echo "Running step1 - detect and merge variants"
-      echo "Running step1 - detect and merge variants - removing old output dir if it exists"
+      #echo "Running step1 - detect and merge variants - removing old output dir if it exists"
       #if [ -d "$WORKING_DIR"/out ]; then rm -Rf "$WORKING_DIR"/out; fi
       echo "Running step1 - detect and merge variants - generating Makefile"
       perl "$WORKING_DIR"/scripts/step1-detect-and-merge-variants.pl ${dollar}{formatted_chromosomes_string} 
@@ -893,7 +890,7 @@ workflow TopMedVariantCaller {
       
 
       echo "Running step2 - joint genotyping"
-      echo "Running step2 - joint genotyping - removing old output dir if it exists"
+      #echo "Running step2 - joint genotyping - removing old output dir if it exists"
       #if [ -d "$WORKING_DIR"/paste ]; then rm -Rf "$WORKING_DIR"/paste; fi
       echo "Running step2 - joint genotyping - generating Makefile"
       perl "$WORKING_DIR"/scripts/step2-joint-genotyping.pl ${dollar}{formatted_chromosomes_string}

--- a/variant-caller/variant-caller-wdl/topmed_freeze3_calling.wdl
+++ b/variant-caller/variant-caller-wdl/topmed_freeze3_calling.wdl
@@ -78,9 +78,10 @@ workflow TopMedVariantCaller {
   Int? VariantCaller_maxretries_tries
   Int VariantCaller_maxretries_tries_default = select_first([VariantCaller_maxretries_tries, 3])
   Int? VariantCaller_memory
-  Int VariantCaller_memory_default = select_first([VariantCaller_memory, 200])
+  # Select memory and CPUs to choose a GCP n1-highmem-64 machine
+  Int VariantCaller_memory_default = select_first([VariantCaller_memory, 400])
   Int? VariantCaller_CPUs
-  Int VariantCaller_CPUs_default = select_first([VariantCaller_CPUs, 32])
+  Int VariantCaller_CPUs_default = select_first([VariantCaller_CPUs, 64])
   # For adding more disk space for the variant caller from an input file
   Int? VariantCaller_additional_disk
   Int VariantCaller_additional_disk_default = select_first([VariantCaller_additional_disk, 1])
@@ -534,8 +535,11 @@ workflow TopMedVariantCaller {
      String? chromosomes
      String chromosomes_to_process = select_first([chromosomes, "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 X" ])
 
+     # The number of jobs to run is the number of cores to use
+     # Typically we use n1-highmem-64 but with 32 processes (ie, -j 32)
+     # These are hyperthreaded cores, so we hope to get a slight performance boost by over-allocating cpus
      Int? num_of_jobs
-     Int num_of_jobs_to_run = select_first([num_of_jobs, 23 ])
+     Int num_of_jobs_to_run = select_first([num_of_jobs, 32 ])
 
      Int? discoverUnit
      Int? genotypeUnit 

--- a/variant-caller/variant-caller-wdl/topmed_freeze3_calling.wdl
+++ b/variant-caller/variant-caller-wdl/topmed_freeze3_calling.wdl
@@ -81,6 +81,9 @@ workflow TopMedVariantCaller {
   Int VariantCaller_memory_default = select_first([VariantCaller_memory, 200])
   Int? VariantCaller_CPUs
   Int VariantCaller_CPUs_default = select_first([VariantCaller_CPUs, 32])
+  # For adding more disk space for the variant caller from an input file
+  Int? VariantCaller_additional_disk
+  Int VariantCaller_additional_disk_default = select_first([VariantCaller_additional_disk, 1])
 
 
 
@@ -369,7 +372,7 @@ workflow TopMedVariantCaller {
       input_crais = crai_files,
       input_crams = input_cram_files,
 
-      disk_size = cram_files_size + crai_files_size + reference_size + additional_disk,
+      disk_size = cram_files_size + crai_files_size + reference_size + additional_disk + VariantCaller_additional_disk_default,
 
       CPUs = VariantCaller_CPUs_default,
       preemptible_tries = VariantCaller_preemptible_tries_default,


### PR DESCRIPTION
Enable disk size override for FireCloud
Fix variant caller to write output to Cromwell directory (outside container)