### PR TITLE
Reverting to gs style URL, adding samtools index to remove CRAI requirement; both needed to play nicely on Terra

### DIFF
--- a/aligner/u_of_michigan_aligner/u_of_michigan_aligner.json
+++ b/aligner/u_of_michigan_aligner/u_of_michigan_aligner.json
@@ -1,18 +1,18 @@
 {
-  "TopMedAligner.input_cram_file": "https://storage.googleapis.com/topmed_workflow_testing/topmed_aligner/input_files/NWD176325.25reads.cram",
-  "TopMedAligner.input_crai_file": "https://storage.googleapis.com/topmed_workflow_testing/topmed_aligner/input_files/NWD176325.25reads.cram.crai",
+  "TopMedAligner.input_cram_file": "gs://topmed_workflow_testing/topmed_aligner/input_files/NWD176325.25reads.cram",
+  "TopMedAligner.input_crai_file": "gs://topmed_workflow_testing/topmed_aligner/input_files/NWD176325.25reads.cram.crai",
 
-  "TopMedAligner.ref_alt":  "https://storage.googleapis.com/topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.alt",
-  "TopMedAligner.ref_bwt":  "https://storage.googleapis.com/topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.bwt",
-  "TopMedAligner.ref_pac":  "https://storage.googleapis.com/topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.pac",
-  "TopMedAligner.ref_ann":  "https://storage.googleapis.com/topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.ann",
-  "TopMedAligner.ref_amb":  "https://storage.googleapis.com/topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.amb",
-  "TopMedAligner.ref_sa":  "https://storage.googleapis.com/topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.sa",
-  "TopMedAligner.ref_fasta":  "https://storage.googleapis.com/topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa",
-  "TopMedAligner.ref_fasta_index":  "https://storage.googleapis.com/topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.fai",
+  "TopMedAligner.ref_alt":  "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.alt",
+  "TopMedAligner.ref_bwt":  "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.bwt",
+  "TopMedAligner.ref_pac":  "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.pac",
+  "TopMedAligner.ref_ann":  "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.ann",
+  "TopMedAligner.ref_amb":  "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.amb",
+  "TopMedAligner.ref_sa":  "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.sa",
+  "TopMedAligner.ref_fasta":  "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa",
+  "TopMedAligner.ref_fasta_index":  "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.fai",
 
-  "TopMedAligner.dbSNP_vcf": "https://storage.googleapis.com/topmed_workflow_testing/topmed_aligner/reference_files/hg38/Homo_sapiens_assembly38.dbsnp138.vcf.gz",
-  "TopMedAligner.dbSNP_vcf_index": "https://storage.googleapis.com/topmed_workflow_testing/topmed_aligner/reference_files/hg38/Homo_sapiens_assembly38.dbsnp138.vcf.gz.tbi",
+  "TopMedAligner.dbSNP_vcf": "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/Homo_sapiens_assembly38.dbsnp138.vcf.gz",
+  "TopMedAligner.dbSNP_vcf_index": "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/Homo_sapiens_assembly38.dbsnp138.vcf.gz.tbi",
 
   "TopMedAligner.docker_image": "statgen/alignment:1.0.0"
 }

--- a/aligner/u_of_michigan_aligner/u_of_michigan_aligner.wdl
+++ b/aligner/u_of_michigan_aligner/u_of_michigan_aligner.wdl
@@ -12,7 +12,7 @@
 
 workflow TopMedAligner {
 
-  File input_crai_file
+  File? input_crai_file
   File input_cram_file
 
   String docker_image
@@ -224,7 +224,7 @@ workflow TopMedAligner {
 }
 
   task PreAlign {
-     File input_crai
+     File? input_crai
      File input_cram
 
      File ref_fasta
@@ -254,6 +254,10 @@ workflow TopMedAligner {
       #to turn off echo do 'set +o xtrace'
 
       echo "Running pre-alignment"
+
+      samtools index -b ${input_cram} ${input_cram}.crai
+
+      echo "File indexed, now running the rest of pre-alignment"
 
       samtools view -T ${ref_fasta} -uh -F 0x900 ${input_cram} \
         | bam-ext-mem-sort-manager squeeze --in -.ubam --keepDups --rmTags AS:i,BD:Z,BI:Z,XS:i,MC:Z,MD:Z,NM:i,MQ:i --out -.ubam \


### PR DESCRIPTION
Terra cannot handle "https://storage.googleapis.com" URLs. As the Docstore version of this workflow will become a featured workflow on Terra, this test JSON must be in gs:// form. This also makes it consistent with the variant calling workflow for TOPMed data, as that one is already in gs:// form. I have already tested these URLs on Terra and they work.

This is technically a reversion as these URLs used to be in gs:// form.