### PR TITLE
Feature/terra support11

### DIFF
--- a/CRAM-no-header-md5sum/CRAM_md5sum_checker_wrapper.wdl
+++ b/CRAM-no-header-md5sum/CRAM_md5sum_checker_wrapper.wdl
@@ -1,5 +1,5 @@
-import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.30.0/CRAM-no-header-md5sum/md5sum/CRAM_md5sum.wdl" as f1
-import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.30.0/CRAM-no-header-md5sum/checker/CRAM_md5sum_checker.wdl" as f2
+import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.32.0/CRAM-no-header-md5sum/md5sum/CRAM_md5sum.wdl" as f1
+import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.32.0/CRAM-no-header-md5sum/checker/CRAM_md5sum_checker.wdl" as f2
 
 workflow CRAMMd5sumChecker {
   File inputCRAMFile

--- a/aligner/functional-equivalence-checker/checker-workflow-wrapping-alignment-workflow.wdl
+++ b/aligner/functional-equivalence-checker/checker-workflow-wrapping-alignment-workflow.wdl
@@ -1,5 +1,5 @@
-import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.30.0/aligner/functional-equivalence-wdl/FunctionalEquivalence.wdl" as TopMed_aligner
-import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.30.0/aligner/functional-equivalence-checker/topmed-alignment-checker.wdl" as checker
+import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.32.0/aligner/functional-equivalence-wdl/FunctionalEquivalence.wdl" as TopMed_aligner
+import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.32.0/aligner/functional-equivalence-checker/topmed-alignment-checker.wdl" as checker
 
 workflow checkerWorkflow {
   Int expectedNumofReads

--- a/aligner/functional-equivalence-wdl/FunctionalEquivalence.wdl
+++ b/aligner/functional-equivalence-wdl/FunctionalEquivalence.wdl
@@ -273,6 +273,11 @@ workflow PairedEndSingleSampleWorkflow {
     File output_cram_index = ConvertToCram.output_cram_index
     File output_cram_md5 = ConvertToCram.output_cram_md5
   }
+  meta {
+              author : "Ruchi Munshi"
+              email : "rmunshi@broadinstitute.org"
+              description: "A WDL workflow based on the [CCDG pipeline standards](https://github.com/CCDG/Pipeline-Standardization/blob/master/PipelineStandard.md) for processing high-throughput sequencing data."
+    }
 }
 
 # TASK DEFINITIONS

--- a/aligner/sbg-alignment-cwl/topmed-alignment.cwl
+++ b/aligner/sbg-alignment-cwl/topmed-alignment.cwl
@@ -4,6 +4,8 @@ id: topmed_alignment
 doc: >-
   A CWL wrapper of the TopMed alignment workflow described here:
   https://github.com/statgen/docker-alignment
+  Tool Author: Hyun Min Kang (hmkang@umich.edu) and Adrian Tan (atks@umich.edu)
+  Wrapper Author: Marko Zecevic (marko.zecevic@sbgenomics.com)
 label: TOPMed Alignment
 $namespaces:
   sbg: 'https://sevenbridges.com'

--- a/aligner/topmed-cwl/workflow/alignment_workflow.cwl
+++ b/aligner/topmed-cwl/workflow/alignment_workflow.cwl
@@ -12,6 +12,9 @@ doc: |
       - reads are provided in query-sorted order
       - all reads must have an RG tag
     - Reference genome must be Hg38 with ALT contigs
+'dct:creator':
+  'foaf:mbox': 'mailto:yilinxu@uchicago.edu'
+  'foaf:name': Yilin Xu
 
 class: Workflow
 id: alignment_pipeline

--- a/aligner/u_of_michigan_aligner-checker/u_of_michigan_aligner_checker.wdl
+++ b/aligner/u_of_michigan_aligner-checker/u_of_michigan_aligner_checker.wdl
@@ -1,5 +1,5 @@
-import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.30.0/aligner/u_of_michigan_aligner/u_of_michigan_aligner.wdl" as TopMed_aligner
-import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.30.0/aligner/u_of_michigan_aligner-checker/u_of_michigan_aligner_checker_calculation.wdl" as checker
+import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.32.0/aligner/u_of_michigan_aligner/u_of_michigan_aligner.wdl" as TopMed_aligner
+import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.32.0/aligner/u_of_michigan_aligner-checker/u_of_michigan_aligner_checker_calculation.wdl" as checker
 
 workflow checkerWorkflow {
   String docker_image

--- a/aligner/u_of_michigan_aligner/u_of_michigan_aligner.json
+++ b/aligner/u_of_michigan_aligner/u_of_michigan_aligner.json
@@ -1,18 +1,18 @@
 {
-  "TopMedAligner.input_cram_file": "https://storage.googleapis.com/topmed_workflow_testing/topmed_aligner/input_files/NWD176325.25reads.cram",
-  "TopMedAligner.input_crai_file": "https://storage.googleapis.com/topmed_workflow_testing/topmed_aligner/input_files/NWD176325.25reads.cram.crai",
+  "TopMedAligner.input_cram_file": "gs://topmed_workflow_testing/topmed_aligner/input_files/NWD176325.25reads.cram",
+  "TopMedAligner.input_crai_file": "gs://topmed_workflow_testing/topmed_aligner/input_files/NWD176325.25reads.cram.crai",
 
-  "TopMedAligner.ref_alt":  "https://storage.googleapis.com/topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.alt",
-  "TopMedAligner.ref_bwt":  "https://storage.googleapis.com/topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.bwt",
-  "TopMedAligner.ref_pac":  "https://storage.googleapis.com/topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.pac",
-  "TopMedAligner.ref_ann":  "https://storage.googleapis.com/topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.ann",
-  "TopMedAligner.ref_amb":  "https://storage.googleapis.com/topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.amb",
-  "TopMedAligner.ref_sa":  "https://storage.googleapis.com/topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.sa",
-  "TopMedAligner.ref_fasta":  "https://storage.googleapis.com/topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa",
-  "TopMedAligner.ref_fasta_index":  "https://storage.googleapis.com/topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.fai",
+  "TopMedAligner.ref_alt":  "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.alt",
+  "TopMedAligner.ref_bwt":  "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.bwt",
+  "TopMedAligner.ref_pac":  "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.pac",
+  "TopMedAligner.ref_ann":  "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.ann",
+  "TopMedAligner.ref_amb":  "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.amb",
+  "TopMedAligner.ref_sa":  "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.sa",
+  "TopMedAligner.ref_fasta":  "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa",
+  "TopMedAligner.ref_fasta_index":  "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.fai",
 
-  "TopMedAligner.dbSNP_vcf": "https://storage.googleapis.com/topmed_workflow_testing/topmed_aligner/reference_files/hg38/Homo_sapiens_assembly38.dbsnp138.vcf.gz",
-  "TopMedAligner.dbSNP_vcf_index": "https://storage.googleapis.com/topmed_workflow_testing/topmed_aligner/reference_files/hg38/Homo_sapiens_assembly38.dbsnp138.vcf.gz.tbi",
+  "TopMedAligner.dbSNP_vcf": "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/Homo_sapiens_assembly38.dbsnp138.vcf.gz",
+  "TopMedAligner.dbSNP_vcf_index": "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/Homo_sapiens_assembly38.dbsnp138.vcf.gz.tbi",
 
   "TopMedAligner.docker_image": "statgen/alignment:1.0.0"
 }

--- a/aligner/u_of_michigan_aligner/u_of_michigan_aligner.wdl
+++ b/aligner/u_of_michigan_aligner/u_of_michigan_aligner.wdl
@@ -12,7 +12,7 @@
 
 workflow TopMedAligner {
 
-  File input_crai_file
+  File? input_crai_file
   File input_cram_file
 
   String docker_image
@@ -224,7 +224,7 @@ workflow TopMedAligner {
 }
 
   task PreAlign {
-     File input_crai
+     File? input_crai
      File input_cram
 
      File ref_fasta
@@ -254,6 +254,10 @@ workflow TopMedAligner {
       #to turn off echo do 'set +o xtrace'
 
       echo "Running pre-alignment"
+
+      samtools index -b ${input_cram} ${input_cram}.crai
+
+      echo "File indexed, now running the rest of pre-alignment"
 
       samtools view -T ${ref_fasta} -uh -F 0x900 ${input_cram} \
         | bam-ext-mem-sort-manager squeeze --in -.ubam --keepDups --rmTags AS:i,BD:Z,BI:Z,XS:i,MC:Z,MD:Z,NM:i,MQ:i --out -.ubam \

--- a/aligner/u_of_michigan_aligner/u_of_michigan_aligner.wdl
+++ b/aligner/u_of_michigan_aligner/u_of_michigan_aligner.wdl
@@ -216,6 +216,11 @@ workflow TopMedAligner {
       File aligner_output_cram = PostAlign.output_cram_file
       File aligner_output_crai = PostAlign.output_crai_file
   }
+  meta {
+            author : "Walt Shands"
+            email : "jshands@ucsc.edu"
+            description: "This is the workflow WDL for the [TOPMed/University of Michigan alignment pipeline](https://github.com/statgen/docker-alignment)"
+  }
 }
 
   task PreAlign {

--- a/variant-caller/sbg-variant-caller-cwl/topmed_freeze3_calling/topmed_freeze3_calling.cwl
+++ b/variant-caller/sbg-variant-caller-cwl/topmed_freeze3_calling/topmed_freeze3_calling.cwl
@@ -2,6 +2,8 @@ class: CommandLineTool
 cwlVersion: v1.0
 id: >-
   vladimir_obucina/topmed-freeze-3a-variant-calling-pipeline/topmed_freeze3_calling/25
+doc: >-
+  This is the CWL wrapper for U of Michigan's [TOPMed Freeze 3a Variant Calling Pipeline](https://github.com/statgen/topmed_freeze3_calling)
 baseCommand: []
 inputs:
   - format: 'BAI,CRAI'
@@ -545,4 +547,7 @@ $namespaces:
 'sbg:projectName': TOPMed Freeze 3a Variant Calling Pipeline
 'sbg:createdBy': mikojicic
 'sbg:modifiedBy': vladimir_obucina
+'dct:creator':
+  'foaf:mbox': 'mailto:vladimir.obucina@sbgenomics.com'
+  'foaf:name': Vladimir Obucina
 'sbg:validationErrors': []

--- a/variant-caller/sbg-variant-caller-cwl/topmed_variant_calling_pipeline.cwl
+++ b/variant-caller/sbg-variant-caller-cwl/topmed_variant_calling_pipeline.cwl
@@ -2,6 +2,8 @@ class: Workflow
 cwlVersion: v1.0
 id: >-
   vladimir_obucina/topmed-freeze-3a-variant-calling-pipeline/topmed-variant-calling-pipeline-cwl1/17
+doc: >-
+    This is the CWL wrapper for U of Michigan's [TOPMed Freeze 3a Variant Calling Pipeline](https://github.com/statgen/topmed_freeze3_calling)
 label: TOPMed Variant Calling Pipeline CWL1
 inputs:
   - id: reference
@@ -150,4 +152,7 @@ requirements:
     - class: InlineJavascriptRequirement
 $namespaces:
   sbg: 'https://sevenbridges.com'
+'dct:creator':
+  'foaf:mbox': 'mailto:vladimir.obucina@sbgenomics.com'
+  'foaf:name': Vladimir Obucina
 

--- a/variant-caller/variant-caller-wdl-checker/topmed_freeze3_calling_checker.wdl
+++ b/variant-caller/variant-caller-wdl-checker/topmed_freeze3_calling_checker.wdl
@@ -1,5 +1,5 @@
-import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.30.0/variant-caller/variant-caller-wdl/topmed_freeze3_calling.wdl" as TopMed_variantcaller
-import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.30.0/variant-caller/variant-caller-wdl-checker/topmed-variantcaller-checker.wdl" as checker
+import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.32.0/variant-caller/variant-caller-wdl/topmed_freeze3_calling.wdl" as TopMed_variantcaller
+import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.32.0/variant-caller/variant-caller-wdl-checker/topmed-variantcaller-checker.wdl" as checker
 
 workflow checkerWorkflow {
   File inputTruthVCFFile

--- a/variant-caller/variant-caller-wdl/topmed_freeze3_calling.wdl
+++ b/variant-caller/variant-caller-wdl/topmed_freeze3_calling.wdl
@@ -1,4 +1,4 @@
-import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.30.0/variant-caller/variant-caller-wdl/calculate_contamination.wdl" as getDNAContamination
+import "https://raw.githubusercontent.com/DataBiosphere/topmed-workflows/1.32.0/variant-caller/variant-caller-wdl/calculate_contamination.wdl" as getDNAContamination
 
 
 ## This is the U of Michigan variant caller workflow WDL for the workflow code located here:

--- a/variant-caller/variant-caller-wdl/topmed_freeze3_calling.wdl
+++ b/variant-caller/variant-caller-wdl/topmed_freeze3_calling.wdl
@@ -443,6 +443,11 @@ workflow TopMedVariantCaller {
   output {
       File topmed_variant_caller_output = variantCalling.topmed_variant_caller_output_file
   }
+  meta {
+      author : "Walt Shands"
+      email : "jshands@ucsc.edu"
+      description: "This is the workflow WDL for U of Michigan's [TOPMed Freeze 3a Variant Calling Pipeline](https://github.com/statgen/topmed_freeze3_calling)"
+   }
 }
 
  


### PR DESCRIPTION
Adds support for Terra in the following ways:
* Sample JSON reformatted to gs:// style URLs, as Terra cannot parse https:// google storage URLS
* Added a `samtools index `step in the WDL in order to generate CRAI indexes on the fly; this is needed as some datasets such as 1000 Genomes don't come with CRAI files
* Due to the above, made CRAI files an optional argument