### PR TITLE
CRAIs now optional and gs style URLs in add'l JSON

### DIFF
--- a/aligner/u_of_michigan_aligner/u_of_michigan_aligner.wdl
+++ b/aligner/u_of_michigan_aligner/u_of_michigan_aligner.wdl
@@ -12,7 +12,7 @@
 
 workflow TopMedAligner {
 
-  File input_crai_file
+  File? input_crai_file
   File input_cram_file
 
   String docker_image
@@ -224,7 +224,7 @@ workflow TopMedAligner {
 }
 
   task PreAlign {
-     File input_crai
+     File? input_crai
      File input_cram
 
      File ref_fasta

--- a/aligner/u_of_michigan_aligner/u_of_michigan_aligner_gs_urls.json
+++ b/aligner/u_of_michigan_aligner/u_of_michigan_aligner_gs_urls.json
@@ -1,0 +1,18 @@
+{
+  "TopMedAligner.input_cram_file": "gs://topmed_workflow_testing/topmed_aligner/input_files/NWD176325.25reads.cram",
+  "TopMedAligner.input_crai_file": "gs://topmed_workflow_testing/topmed_aligner/input_files/NWD176325.25reads.cram.crai",
+
+  "TopMedAligner.ref_alt":  "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.alt",
+  "TopMedAligner.ref_bwt":  "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.bwt",
+  "TopMedAligner.ref_pac":  "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.pac",
+  "TopMedAligner.ref_ann":  "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.ann",
+  "TopMedAligner.ref_amb":  "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.amb",
+  "TopMedAligner.ref_sa":  "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.sa",
+  "TopMedAligner.ref_fasta":  "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa",
+  "TopMedAligner.ref_fasta_index":  "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/hs38DH.fa.fai",
+
+  "TopMedAligner.dbSNP_vcf": "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/Homo_sapiens_assembly38.dbsnp138.vcf.gz",
+  "TopMedAligner.dbSNP_vcf_index": "gs://topmed_workflow_testing/topmed_aligner/reference_files/hg38/Homo_sapiens_assembly38.dbsnp138.vcf.gz.tbi",
+
+  "TopMedAligner.docker_image": "statgen/alignment:1.0.0"
+}


### PR DESCRIPTION
* CRAI input is now optional
* samtools index not included explictly in spite of optionalality of CRAI as it is already generated on the fly
* added additional test JSON in gs:// format, required by Terra, but it does not replace the https:// JSON
Feel free to close PR#100